### PR TITLE
(GH-14) use of `npm ci` instead of `npm i`

### DIFF
--- a/Cake.VsCode.Recipe/Content/build.cake
+++ b/Cake.VsCode.Recipe/Content/build.cake
@@ -118,9 +118,18 @@ BuildParameters.Tasks.CleanTask = Task("Clean")
 BuildParameters.Tasks.NpmInstallTask = Task("Npm-Install")
     .Does(() =>
 {
-    var settings = new NpmInstallSettings();
-    settings.LogLevel = NpmLogLevel.Silent;
-    NpmInstall(settings);
+    if(BuildParameters.IsLocalBuild) 
+    {
+        var settings = new NpmInstallSettings();
+        settings.LogLevel = NpmLogLevel.Silent;
+        NpmInstall(settings);
+    } 
+    else 
+    {
+        var settings = new NpmCiSettings();
+        settings.LogLevel = NpmLogLevel.Silent;
+        NpmCi(settings);
+    }
 });
 
 BuildParameters.Tasks.InstallTypeScriptTask = Task("Install-TypeScript")


### PR DESCRIPTION
to install all dependencies. This results in `packages.lock.json`
not being updated automatically.

fixes #14 